### PR TITLE
Fix support to multiple paragraphs in a node in ODT generator

### DIFF
--- a/src/templates/odt.sem.py
+++ b/src/templates/odt.sem.py
@@ -135,11 +135,12 @@ def print_nodes(node, niv, lbl_lst):
 	if typo == 'text':
 		y = node.get_val('text')
 		if y:
-			out('<text:p text:style-name="P1">')
-			out('<text:span text:style-name="T1">')
-			out(clear_html(y))
-			out('</text:span>')
-			out('</text:p>')
+			for p in clear_html(y).split('\n\n'):
+				out('<text:p text:style-name="P1">')
+				out('<text:span text:style-name="T1">')
+				out(p)
+				out('</text:span>')
+				out('</text:p>')
 
 	elif typo == 'table':
 		rows = node.num_rows()


### PR DESCRIPTION
Generator for ODT files put all text in a node in a single paragraph, while HTML generator works fine.
This patch makes ODT works like HTML generator.